### PR TITLE
fixes: 1.activity service wasn't wired to session service - when a us…

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/Activities.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/Activities.java
@@ -52,11 +52,11 @@ public class Activities implements Serializable {
 		this.id = id;
 	}
 
-	public LocalDateTime getDateTime(){
+	public LocalDateTime getTimestamp(){
 		return timestamp;
 	}
 
-	public void setDateTime(LocalDateTime timestamp){
+	public void setTimestamp(LocalDateTime timestamp){
 		this.timestamp = timestamp;
 	}
 

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/FriendshipsRepository.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/FriendshipsRepository.java
@@ -11,4 +11,5 @@ import java.util.List;
 @Repository("friendshipsRepository")
 public interface FriendshipsRepository extends JpaRepository<Friendships, Long> {
 	List<Friendships> findByUserA_Id(Long userId);
+	List<Friendships> findByUserB_Id(Long userId);
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/mapper/DTOMapper.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/mapper/DTOMapper.java
@@ -94,6 +94,7 @@ public interface DTOMapper {
     @Mapping(source = "user.username", target = "username")
     @Mapping(source = "book.name", target = "book")
     @Mapping(source = "actions", target = "actions")
+    @Mapping(source = "timestamp", target = "timestamp")
     ActivitiesGetDTO convertActivitiesEntityToGetDTO(Activities activities);
 
     @Mapping(source = "id", target = "id")

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/ActivitiesService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/ActivitiesService.java
@@ -62,7 +62,9 @@ public class ActivitiesService {
 	}
 
 	public List<Activities> getAllActivities(User user) {
-		List<Friendships> friendships = friendshipsRepository.findByUserA_Id(user.getId());
+		List<Friendships> friendships = new ArrayList<>();
+		friendships.addAll(friendshipsRepository.findByUserA_Id(user.getId()));
+		friendships.addAll(friendshipsRepository.findByUserB_Id(user.getId()));
 		List<User> friends = new ArrayList<>(friendships.stream()
 			.map(f -> f.getUserA().equals(user) ? f.getUserB() : f.getUserA())
 			.toList());
@@ -72,7 +74,9 @@ public class ActivitiesService {
 	}
 
 	public List<Activities> getActivitiesByFriend(User user, Long friendId) {
-		List<Friendships> friendships = friendshipsRepository.findByUserA_Id(user.getId());
+		List<Friendships> friendships = new ArrayList<>();
+		friendships.addAll(friendshipsRepository.findByUserA_Id(user.getId()));
+		friendships.addAll(friendshipsRepository.findByUserB_Id(user.getId()));
 		boolean isFriend = friendships.stream()
 		.anyMatch(f ->
 			f.getUserA().getId().equals(friendId) || f.getUserB().getId().equals(friendId));
@@ -89,7 +93,7 @@ public class ActivitiesService {
 		Activities newActivity = new Activities();
 		newActivity.setUser(user);
 		newActivity.setBook(book);
-		newActivity.setDateTime(LocalDateTime.now());
+		newActivity.setTimestamp(LocalDateTime.now());
 
 		if (status == BookStatus.FINISHED){
 			newActivity.setActions("finished reading");

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/LibraryService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/LibraryService.java
@@ -25,6 +25,7 @@ import ch.uzh.ifi.hase.soprafs26.service.ActivitiesService;
 import ch.uzh.ifi.hase.soprafs26.constant.BookStatus;
 
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @Transactional
@@ -121,7 +122,24 @@ public class LibraryService {
         }
 
         shelf.addBook(book);
-        return shelfRepository.save(shelf);
+        Shelf savedShelf = shelfRepository.save(shelf);
+
+        // Create activity when a book lands on a status shelf via direct shelf add
+        String shelfName = shelf.getName();
+        if ("Recent Readings".equals(shelfName) || "Read".equals(shelfName)) {
+            BookStatus statusForShelf = "Recent Readings".equals(shelfName) ? BookStatus.READING : BookStatus.FINISHED;
+            // Update the persisted ShelfBook's status to match the shelf
+            savedShelf.getBooks().stream()
+                .filter(sb -> sb.getBook().getId().equals(book.getId()))
+                .findFirst()
+                .ifPresent(sb -> {
+                    sb.setStatus(statusForShelf);
+                    shelfbookRepository.save(sb);
+                });
+            activitiesService.addActivity(user, statusForShelf, book);
+        }
+
+        return savedShelf;
     }
 
     public void deleteBookfromShelf(Long shelfId, String bookId, Long userId){
@@ -167,6 +185,7 @@ public class LibraryService {
         ShelfBook shelfBook = shelfbookRepository.findByShelfIdAndBookId(shelfId, bookId)
         .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Book not found on this shelf"));
 
+        BookStatus previousStatus = shelfBook.getStatus();
         shelfBook.setStatus(newStatus);
 
         User user = shelf.getShared() //Find the right user for the activity log
@@ -178,26 +197,44 @@ public class LibraryService {
 
         Book book = shelfBook.getBook();
 
-        // Remove book from whichever status shelf it currently exists on (if any)
-        List<String> statusShelfNames = List.of("To Read", "Recent Readings", "Read");
-        shelfbookRepository.findByShelf_OwnerIdAndBookIdAndShelf_NameIn(user.getId(), bookId, statusShelfNames)
-            .ifPresent(shelfbookRepository::delete);
-
-        // Add to the new status shelf
         String targetShelfName = newStatus == BookStatus.READING ? "Recent Readings"
                                : newStatus == BookStatus.FINISHED ? "Read"
                                : "To Read";
 
-        Shelf targetShelf = user.getShelves().stream()
-            .filter(s -> targetShelfName.equals(s.getName()))
-            .findFirst()
-            .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, targetShelfName + " shelf not found"));
+        // Move book between status shelves only when necessary
+        List<String> statusShelfNames = List.of("To Read", "Recent Readings", "Read");
+        Optional<ShelfBook> existingStatusEntry = shelfbookRepository
+            .findByShelf_OwnerIdAndBookIdAndShelf_NameIn(user.getId(), bookId, statusShelfNames);
 
-        targetShelf.addBook(book);
-        shelfRepository.save(targetShelf);
+        boolean alreadyOnTargetShelf = existingStatusEntry.isPresent()
+            && existingStatusEntry.get().getShelf().getName().equals(targetShelfName);
 
-        shelfbookRepository.save(shelfBook);
-        activitiesService.addActivity(user, newStatus, book);
+        if (!alreadyOnTargetShelf) {
+            // Remove from whichever status shelf it's currently on (if any)
+            existingStatusEntry.ifPresent(shelfbookRepository::delete);
+
+            // Add to the target status shelf
+            Shelf targetShelf = user.getShelves().stream()
+                .filter(s -> targetShelfName.equals(s.getName()))
+                .findFirst()
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, targetShelfName + " shelf not found"));
+            targetShelf.addBook(book);
+            shelfRepository.save(targetShelf);
+        }
+
+        // Only save shelfBook if it wasn't the entity we just deleted
+        boolean shelfBookWasDeleted = existingStatusEntry.isPresent()
+            && !alreadyOnTargetShelf
+            && existingStatusEntry.get().getId().equals(shelfBook.getId());
+
+        if (!shelfBookWasDeleted) {
+            shelfbookRepository.save(shelfBook);
+        }
+
+        // Only create activity when status actually changes to avoid duplicates
+        if (previousStatus != newStatus) {
+            activitiesService.addActivity(user, newStatus, book);
+        }
 
         return shelfBook;
     }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SessionService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SessionService.java
@@ -12,6 +12,7 @@ import ch.uzh.ifi.hase.soprafs26.repository.SessionParticipantRepository;
 import ch.uzh.ifi.hase.soprafs26.repository.SessionRepository;
 import ch.uzh.ifi.hase.soprafs26.repository.ShelfBookRepository;
 import ch.uzh.ifi.hase.soprafs26.repository.UserRepository;
+import ch.uzh.ifi.hase.soprafs26.service.ActivitiesService;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.BookGetDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.SessionParticipantGetDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.SessionParticipantPostDTO;
@@ -40,6 +41,7 @@ public class SessionService {
     private final SessionParticipantRepository sessionParticipantRepository;
     private final LeaderboardRepository leaderboardRepository;
     private final NotificationService notificationService;
+    private final ActivitiesService activitiesService;
 
     @Autowired
     public SessionService(SessionRepository sessionRepository,
@@ -48,13 +50,15 @@ public class SessionService {
                           SessionParticipantRepository sessionParticipantRepository,
                           LibraryService libraryService,
                           LeaderboardRepository leaderboardRepository,
-                          NotificationService notificationService) {
+                          NotificationService notificationService,
+                          ActivitiesService activitiesService) {
         this.sessionRepository = sessionRepository;
         this.userRepository = userRepository;
         this.shelfbookRepository = shelfbookRepository;
         this.sessionParticipantRepository = sessionParticipantRepository;
         this.leaderboardRepository = leaderboardRepository;
         this.notificationService = notificationService;
+        this.activitiesService = activitiesService;
     }
 
     public void sendSessionNotification(Long sessionId, Long senderId, List<Long> participantIds)
@@ -158,6 +162,7 @@ public class SessionService {
         shelfBookModel.setPagesRead(shelfBook.getPagesRead());
         shelfBookModel.setBook(bookModel);
         shelfBook.setStatus(BookStatus.READING);
+        activitiesService.addActivity(user, BookStatus.READING, shelfBook.getBook());
 
         List<Long> participantIds = session.getParticipants()
             .stream()

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,4 @@
 server.port=8080
-spring.jackson.serialization.write-dates-as-timestamps=false
 
 # Enabling the H2-Console (local and remote)
 spring.h2.console.enabled=true

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,4 +1,5 @@
 server.port=8080
+spring.jackson.serialization.write-dates-as-timestamps=false
 
 # Enabling the H2-Console (local and remote)
 spring.h2.console.enabled=true


### PR DESCRIPTION
…er joined a reading session the book status was changed but the addActivity function was never called. 2. updateBookStatus was not being used as intended, now it checks if the book is already on the target status shelf before deleting/re-adding it, tracks whether shelfBook was the entity deleted, and only creates the activity when the status actually changes. 3. activities are created when user adds book to Recent Reading or Read shelves. Not only when clicking on Start Reading.